### PR TITLE
Fix voting and day/night phase bugs

### DIFF
--- a/ubg/src/mafia/MafiaDay.js
+++ b/ubg/src/mafia/MafiaDay.js
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
  * @return {ReactElement} Mafia day element
  */
 function MafiaDay({mafiaKill, doctorSave, usersData,
-  usersCollection, userUid, userAlive, room, dayVote, end}) {
+  usersCollection, userUid, room, dayVote, end}) {
   const classes = useStyles();
   const [players, setPlayers] = React.useState([]);
   const [userInfo, setUserInfo] = React.useState('');
@@ -47,19 +47,17 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
   const [win, setWin] = useState(0);
   const [initialize, setInitialize] = useState(false);
   const alive = () => {
-    let count = 0;
     const allPlayers = [];
     usersData.forEach(function(u) {
       if (u.alive === true) {
         allPlayers.push(u);
-        count++;
       }
       if (u.uid === userUid) {
         setUserInfo(u);
       }
     });
     setPlayers(allPlayers);
-    return count;
+    return allPlayers.length;
   };
 
   /**
@@ -162,8 +160,10 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
         dayVote: firebase.firestore.FieldValue.arrayUnion(newVote),
       });
       setVoted(true);
+      alert('You have voted for ' + choice.displayName);
+    } else {
+      alert('You have already voted for ' + choice.displayName);
     }
-    alert('You have voted for ' + choice.displayName);
   }
 
   return (
@@ -201,7 +201,7 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
               variant="contained"
               color="primary"
               onClick={confirmVote}
-              disabled={!userAlive}
+              disabled={!userInfo.alive}
             >
               Confirm Vote
             </Button>
@@ -237,7 +237,6 @@ MafiaDay.propTypes = {
 
 const mapStateToProps = (state) => ({
   userUid: state.currentUser.uid,
-  userAlive: state.currentUser.alive,
   usersData: state.usersData,
   dayVote: state.roomData.dayVote,
   mafiaKill: state.roomData.mafiaKill,

--- a/ubg/src/mafia/MafiaDay.js
+++ b/ubg/src/mafia/MafiaDay.js
@@ -81,14 +81,12 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
         usersCollection.doc(mafiaKill.uid).update({alive: false});
         setDeathText(mafiaKill.displayName + ' was killed last night');
         aliveNum -= 1;
-        // room.update({
-        //   aliveCount: aliveCount - 1,
-        // });
       } else {
         setDeathText('No one was killed last night');
       }
       usersData.forEach(function(u) {
-        if (u.alive === true) {
+        if (u.alive === true &&
+          (u.uid !== mafiaKill.uid && mafiaKill.uid !== doctorSave)) {
           allPlayers.push(u);
         }
         if (u.uid === userUid) {
@@ -172,6 +170,8 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
       });
       setVoted(true);
       alert('You have voted for ' + choice.displayName);
+    } else {
+      alert('You have already voted for ' + choice.displayName);
     }
   }
 
@@ -210,6 +210,7 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
               variant="contained"
               color="primary"
               onClick={confirmVote}
+              disabled={!userInfo.alive}
             >
               Confirm Vote
             </Button>

--- a/ubg/src/mafia/MafiaDay.js
+++ b/ubg/src/mafia/MafiaDay.js
@@ -207,7 +207,6 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
               variant="contained"
               color="primary"
               onClick={confirmVote}
-              disabled={disabled}
             >
               Confirm Vote
             </Button>

--- a/ubg/src/mafia/MafiaDay.js
+++ b/ubg/src/mafia/MafiaDay.js
@@ -46,7 +46,6 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
   const [voted, setVoted] = useState(false);
   const [win, setWin] = useState(0);
   const [initialize, setInitialize] = useState(false);
-  // const [disabled, setDisabled] = useState(false);
 
   /**
    * Determines if game has reached end
@@ -139,14 +138,6 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
       }
     }
   }
-
-  /**
-   * Checks if player is dead or if they already voted,
-   * The confirm vote button will be disabled if true.
-   */
-  // function canVote() {
-  //   setDisabled(!userInfo.alive || voted);
-  // }
 
   useEffect(startDay, [usersData]);
   useEffect(startNight, [dayVote]);

--- a/ubg/src/mafia/MafiaDay.js
+++ b/ubg/src/mafia/MafiaDay.js
@@ -81,7 +81,7 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
         usersCollection.doc(mafiaKill.uid).update({alive: false});
         setDeathText(mafiaKill.displayName + ' was killed last night');
         room.update({
-          aliveCount: aliveCount - 1, 
+          aliveCount: aliveCount - 1,
         });
       } else {
         setDeathText('No one was killed last night');
@@ -139,6 +139,10 @@ function MafiaDay({mafiaKill, doctorSave, usersData,
     }
   }
 
+  /**
+   * Checks if player is dead or if they already voted,
+   * The confirm vote button will be disabled if true.
+   */
   function canVote() {
     setDisabled(!userInfo.alive || voted);
   }

--- a/ubg/src/pages/Room.js
+++ b/ubg/src/pages/Room.js
@@ -205,6 +205,7 @@ function Room({setUsersData, setCurrentUser, setRoomData}) {
       mafiaKill: {'uid': '', 'displayName': ''},
       detectiveCheck: {'uid': '', 'displayName': ''},
       started: true,
+      aliveCount: usersData.length,
       dayVote: [],
     }).catch(function(error) {
       console.error('Error starting game: ', error);


### PR DESCRIPTION
I had to use a kind of a hack-y solution in order to fix the voting issue. When counting if everyone voted, I should be able to check dayVote.length === players.length, but for some reason players.length is always 0 when the startNight method is called. I directly call alive() when doing the check, which I know isn't the most efficient way. Not sure what I can do about that.