### PR TITLE
Fix profile page bugs

### DIFF
--- a/ubg/src/App.js
+++ b/ubg/src/App.js
@@ -52,9 +52,6 @@ function App() {
               <Route exact path="/search/:query">
                 <Search />
               </Route>
-              <Route exact path="/profile">
-                <Profile />
-              </Route>
               <Route exact path="/profile/:uid">
                 <Profile />
               </Route>

--- a/ubg/src/common/ProfileMenu.js
+++ b/ubg/src/common/ProfileMenu.js
@@ -85,7 +85,11 @@ export default function AuthButtons() {
    * @return {void}
    */
   function toProfile() {
-    history.push(`/profile`);
+    if (user) {
+      history.push(`/profile/` + user.uid);
+    } else {
+      history.push('/');
+    }
   };
 
   return (

--- a/ubg/src/friend/FriendRequests.js
+++ b/ubg/src/friend/FriendRequests.js
@@ -13,7 +13,6 @@ import {useFirestore} from 'reactfire';
  */
 export default function FriendRequests({users, currUser}) {
   const userCollection = useFirestore().collection('users');
-  console.log(users);
 
   return (
     // iterate through all users

--- a/ubg/src/friend/Request.js
+++ b/ubg/src/friend/Request.js
@@ -17,8 +17,7 @@ import * as firebase from 'firebase/app';
 export default function Request({user, userCollection, currUser}) {
   const currUserRef = userCollection.doc(currUser.uid);
   const currUserData = useFirestoreDocData(currUserRef);
-  const userRef = userCollection.doc(user);
-  const userData = useFirestoreDocData(userRef);
+  const userRef = userCollection.doc(user.uid);
 
   /**
    * Add as friend to one another and delete request
@@ -30,7 +29,10 @@ export default function Request({user, userCollection, currUser}) {
     });
     // add to requester's friends
     userRef.update({
-      friends: firebase.firestore.FieldValue.arrayUnion(currUser.uid),
+      friends: firebase.firestore.FieldValue.arrayUnion({
+        uid: currUser.uid,
+        displayName: currUser.displayName,
+      }),
     });
     declineRequest();
   }
@@ -41,7 +43,7 @@ export default function Request({user, userCollection, currUser}) {
   function declineRequest() {
     // delete from requests field
     for (let i = 0; i < currUserData.requests.length; i++) {
-      if (currUserData.requests[i] === user) {
+      if (currUserData.requests[i].uid === user.uid) {
         currUserData.requests.splice(i, 1);
         if (currUserData.requests.length === 0) {
           userCollection.doc(currUser.uid).update({
@@ -62,8 +64,8 @@ export default function Request({user, userCollection, currUser}) {
       <Grid container spacing={3}>
         <Grid item>
           <AccountCircleIcon />
-          <Link href={'/profile/' + userRef.id}>
-            &nbsp;{userData.displayName}
+          <Link href={'/profile/' + user.uid}>
+            &nbsp;{user.displayName}
           </Link>
         </Grid>
         <Grid item>
@@ -90,7 +92,7 @@ export default function Request({user, userCollection, currUser}) {
 }
 
 Request.propTypes = {
-  user: PropTypes.string,
+  user: PropTypes.object,
   userCollection: PropTypes.object,
   currUser: PropTypes.object,
 };

--- a/ubg/src/pages/Profile.js
+++ b/ubg/src/pages/Profile.js
@@ -161,6 +161,12 @@ function UserFriends({userCollection, uid}) {
   const userFriends = useFirestoreDocData(
       userCollection.doc(uid)).friends;
 
+  function compare(a, b) {
+    const nameA = a.displayName.toUpperCase();
+    const nameB = b.displayName.toUpperCase();
+    return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
+  }
+
   return (
     <Box m={10}>
       <hr /> <br /> <br />
@@ -176,7 +182,7 @@ function UserFriends({userCollection, uid}) {
         </div> :
         <List width="100%">
           {
-            userFriends.map((friend) => {
+            userFriends.sort(compare).map((friend) => {
               return (
                 <ListItem key={friend}>
                   <Friend friend={friend} userCollection={userCollection} />

--- a/ubg/src/profile/Friend.js
+++ b/ubg/src/profile/Friend.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Link from '@material-ui/core/Link';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
-import {useFirestoreDocData} from 'reactfire';
 import PropTypes from 'prop-types';
 
 /**
@@ -10,14 +9,11 @@ import PropTypes from 'prop-types';
  * @return {ReactElement} Friend's link to profile page
  */
 export default function Friend({friend, userCollection}) {
-  const friendRef = userCollection.doc(friend);
-  const friendData = useFirestoreDocData(friendRef);
-
   return (
     <div>
       <AccountCircleIcon />
-      <Link href={'/profile/' + friendRef.id}>
-        &nbsp;{friendData.displayName}
+      <Link href={'/profile/' + friend.uid}>
+        &nbsp;{friend.displayName}
       </Link>
     </div>
   );

--- a/ubg/src/profile/Friend.js
+++ b/ubg/src/profile/Friend.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  * @param {object} userCollection Reference to user collection
  * @return {ReactElement} Friend's link to profile page
  */
-export default function Friend({friend, userCollection}) {
+export default function Friend({friend}) {
   return (
     <div>
       <AccountCircleIcon />
@@ -20,6 +20,5 @@ export default function Friend({friend, userCollection}) {
 }
 
 Friend.propTypes = {
-  friend: PropTypes.string,
-  userCollection: PropTypes.object,
+  friend: PropTypes.object,
 };


### PR DESCRIPTION
1. Friends are stored differently by storing their display name in addition to their uid. This fixes a Material UI bug with card images that won't load if a component is being repeatedly mapped.

2. The user's profile page could not be accessed when trying to access from another user's profile page. This was fixed by deleting the profile/ route and simply using the user's uid in the page path.